### PR TITLE
add custom metrics

### DIFF
--- a/.local/README.md
+++ b/.local/README.md
@@ -7,17 +7,22 @@ Prerequisite: K8s cluster (kind, minikube) with cert-manager installed.
    kubectl apply -f crds
    ```
 
-2. Deploy webhook definitions and according objects:
+2. Copy a sufficently authorized kubeconfig to `.kubeconfig` in the root folder of this repository, e.g.:
+   ```bash
+   cp ~/.kube/config .kubeconfig
+   ```
+
+Afterwards (if using vscode) it should be possible to start the operator with the included launch configuration.
+
+Optional, if you want to test the webhook locally:
+3. Deploy webhook definitions and according objects:
    ```bash
    # replace HOST_IP below with a non-loopback interface address of your desktop
    HOST_IP=1.2.3.4 envsubst < .local/k8s-resources.yaml | kubectl apply -f -
    ```
 
-3. Extract the TLS server keypair:
+4. Extract the TLS server keypair:
    ```bash
    .local/getcerts.sh
    ```
-
-4. Copy a sufficently authorized kubeconfig to `.kubeconfig` in the root folder of this repository.
-
-Afterwards (if using vscode) it should be possible to start the operator with the included launch configuration.
+5. in .vscode/launch.json, set `--enableWebhook=true`

--- a/.local/README.md
+++ b/.local/README.md
@@ -1,13 +1,15 @@
 # Instructions for local development
 
-Prerequisite: K8s cluster (kind, minikube) with cert-manager installed.
+**Prerequisites**: K8s cluster (kind, minikube) with cert-manager installed.
 
 1. Deploy custom resource definnitions:
+
    ```bash
    kubectl apply -f crds
    ```
 
 2. Copy a sufficently authorized kubeconfig to `.kubeconfig` in the root folder of this repository, e.g.:
+
    ```bash
    cp ~/.kube/config .kubeconfig
    ```
@@ -15,14 +17,18 @@ Prerequisite: K8s cluster (kind, minikube) with cert-manager installed.
 Afterwards (if using vscode) it should be possible to start the operator with the included launch configuration.
 
 Optional, if you want to test the webhook locally:
-3. Deploy webhook definitions and according objects:
+
+1. Deploy webhook definitions and according objects:
+
    ```bash
    # replace HOST_IP below with a non-loopback interface address of your desktop
    HOST_IP=1.2.3.4 envsubst < .local/k8s-resources.yaml | kubectl apply -f -
    ```
 
-4. Extract the TLS server keypair:
+2. Extract the TLS server keypair:
+
    ```bash
    .local/getcerts.sh
    ```
-5. in .vscode/launch.json, set `--enableWebhook=true`
+
+3. in .vscode/launch.json, set `--enableWebhook=true`

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -14,6 +14,7 @@
                 "--kubeconfig=${workspaceFolder}/.kubeconfig",
                 "--webhook-bind-address=:2443",
                 "--webhook-tls-directory=${workspaceFolder}/.local/ssl",
+                "--enableWebhooks=false",
                 "--cluster-resource-namespace=default",
                 "--sap-binding-metadata"
             ]

--- a/README-FORK.md
+++ b/README-FORK.md
@@ -1,0 +1,8 @@
+# cf-service-operator
+
+## Pull from original repository
+```sh
+git remote add upstream https://github.com/SAP/cf-service-operator.git
+git fetch upstream
+git merge upstream/main --allow-unrelated-histories
+```

--- a/README-FORK.md
+++ b/README-FORK.md
@@ -1,8 +1,0 @@
-# cf-service-operator
-
-## Pull from original repository
-```sh
-git remote add upstream https://github.com/SAP/cf-service-operator.git
-git fetch upstream
-git merge upstream/main --allow-unrelated-histories
-```

--- a/internal/cf/client.go
+++ b/internal/cf/client.go
@@ -11,8 +11,10 @@ import (
 
 	cfclient "github.com/cloudfoundry-community/go-cfclient/v3/client"
 	cfconfig "github.com/cloudfoundry-community/go-cfclient/v3/config"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
 
 	"github.com/sap/cf-service-operator/internal/facade"
+	cfmetrics "github.com/sap/cf-service-operator/pkg/metrics"
 )
 
 const (
@@ -70,6 +72,13 @@ func newOrganizationClient(organizationName string, url string, username string,
 	if err != nil {
 		return nil, err
 	}
+	httpClient := config.HTTPClient()
+	transport, err := cfmetrics.AddMetricsToTransport(httpClient.Transport, metrics.Registry, "cf-api", url)
+	if err != nil {
+		return nil, err
+	}
+	httpClient.Transport = transport
+	config.WithHTTPClient(httpClient)
 	c, err := cfclient.New(config)
 	if err != nil {
 		return nil, err
@@ -94,6 +103,13 @@ func newSpaceClient(spaceGuid string, url string, username string, password stri
 	if err != nil {
 		return nil, err
 	}
+	httpClient := config.HTTPClient()
+	transport, err := cfmetrics.AddMetricsToTransport(httpClient.Transport, metrics.Registry, "cf-api", url)
+	if err != nil {
+		return nil, err
+	}
+	httpClient.Transport = transport
+	config.WithHTTPClient(httpClient)
 	c, err := cfclient.New(config)
 	if err != nil {
 		return nil, err

--- a/internal/cf/client_test.go
+++ b/internal/cf/client_test.go
@@ -136,6 +136,16 @@ var _ = Describe("CF Client tests", Ordered, func() {
 			Expect(server.ReceivedRequests()[2].URL.Path).To(Equal(spacesURI))
 
 			Expect(server.ReceivedRequests()).To(HaveLen(3))
+
+			// verify metrics
+			metricsList, err := metrics.Registry.Gather()
+			Expect(err).To(BeNil())
+			Expect(metricsList).To(HaveLen(3))
+			for _, m := range metricsList {
+				if *m.Name == "http_client_requests_total" {
+					Expect(m.Metric[0].Counter.GetValue()).To(BeNumerically(">", 0))
+				}
+			}
 		})
 
 		It("should be able to query some org twice", func() {
@@ -220,7 +230,7 @@ var _ = Describe("CF Client tests", Ordered, func() {
 			Expect(server.ReceivedRequests()).To(HaveLen(1))
 		})
 
-		It("should be able to query space", func() {
+		It("should be able to query some space", func() {
 			spaceClient, err := NewSpaceClient(OrgName, url, Username, Password)
 			Expect(err).To(BeNil())
 
@@ -237,6 +247,16 @@ var _ = Describe("CF Client tests", Ordered, func() {
 			Expect(server.ReceivedRequests()[2].URL.Path).To(Equal(serviceInstancesURI))
 
 			Expect(server.ReceivedRequests()).To(HaveLen(3))
+
+			// verify metrics
+			metricsList, err := metrics.Registry.Gather()
+			Expect(err).To(BeNil())
+			Expect(metricsList).To(HaveLen(3))
+			for _, m := range metricsList {
+				if *m.Name == "http_client_requests_total" {
+					Expect(m.Metric[0].Counter.GetValue()).To(BeNumerically(">", 0))
+				}
+			}
 		})
 
 		It("should be able to query some space twice", func() {

--- a/internal/cf/client_test.go
+++ b/internal/cf/client_test.go
@@ -141,11 +141,14 @@ var _ = Describe("CF Client tests", Ordered, func() {
 			metricsList, err := metrics.Registry.Gather()
 			Expect(err).To(BeNil())
 			Expect(metricsList).To(HaveLen(3))
+			verified := false
 			for _, m := range metricsList {
 				if *m.Name == "http_client_requests_total" {
 					Expect(m.Metric[0].Counter.GetValue()).To(BeNumerically(">", 0))
+					verified = true
 				}
 			}
+			Expect(verified).To(BeTrue())
 		})
 
 		It("should be able to query some org twice", func() {
@@ -252,11 +255,14 @@ var _ = Describe("CF Client tests", Ordered, func() {
 			metricsList, err := metrics.Registry.Gather()
 			Expect(err).To(BeNil())
 			Expect(metricsList).To(HaveLen(3))
+			verified := false
 			for _, m := range metricsList {
 				if *m.Name == "http_client_requests_total" {
 					Expect(m.Metric[0].Counter.GetValue()).To(BeNumerically(">", 0))
+					verified = true
 				}
 			}
+			Expect(verified).To(BeTrue())
 		})
 
 		It("should be able to query some space twice", func() {

--- a/internal/cf/client_test.go
+++ b/internal/cf/client_test.go
@@ -326,6 +326,9 @@ var _ = Describe("CF Client tests", Ordered, func() {
 			Expect(metricNames).To(ContainElement("http_client_request_duration_seconds"))
 			Expect(metricNames).To(ContainElement("http_client_requests_in_flight"))
 			Expect(metricNames).To(ContainElement("http_client_requests_total"))
+
+			// for debugging: write metrics to file
+			// prometheus.WriteToTextfile("metrics.txt", metrics.Registry)
 		})
 
 	})

--- a/main.go
+++ b/main.go
@@ -53,12 +53,15 @@ func main() {
 	var webhookAddr string
 	var webhookCertDir string
 	var enableLeaderElection bool
+	var enableWebhooks bool
 	var clusterResourceNamespace string
 	var enableBindingMetadata bool
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
 	flag.StringVar(&webhookAddr, "webhook-bind-address", ":9443", "The address the webhook endpoint binds to.")
+	// TODO: where is webhookCertDir used?
 	flag.StringVar(&webhookCertDir, "webhook-tls-directory", "", "The directory containing tls server key and certificate, as tls.key and tls.crt; defaults to $TMPDIR/k8s-webhook-server/serving-certs.")
+	flag.BoolVar(&enableWebhooks, "enableWebhooks", true, "Enable webhooks in controller. May be disabled for local development.")
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false, "Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager.")
 	flag.StringVar(&clusterResourceNamespace, "cluster-resource-namespace", "", "The namespace for secrets in which cluster-scoped resources are found.")
 	flag.BoolVar(&enableBindingMetadata, "sap-binding-metadata", false, "Enhance binding secrets by SAP binding metadata by default.")
@@ -97,7 +100,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
+	options := ctrl.Options{
 		Scheme: scheme,
 		// TODO: disable cache for further resources (e.g. secrets) ?
 		Client: client.Options{
@@ -113,16 +116,18 @@ func main() {
 		LeaderElection:                enableLeaderElection,
 		LeaderElectionID:              LeaderElectionID,
 		LeaderElectionReleaseOnCancel: true,
-		WebhookServer: webhook.NewServer(webhook.Options{
-			Host:    webhookHost,
-			Port:    webhookPort,
-			CertDir: webhookCertDir,
-		}),
 		Metrics: metricsserver.Options{
 			BindAddress: metricsAddr,
 		},
 		HealthProbeBindAddress: probeAddr,
-	})
+	}
+	if enableWebhooks {
+		options.WebhookServer = webhook.NewServer(webhook.Options{
+			Host: webhookHost,
+			Port: webhookPort,
+		})
+	}
+	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), options)
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")
 		os.Exit(1)
@@ -169,21 +174,23 @@ func main() {
 		setupLog.Error(err, "unable to create controller", "controller", "ServiceBinding")
 		os.Exit(1)
 	}
-	if err = (&cfv1alpha1.Space{}).SetupWebhookWithManager(mgr); err != nil {
-		setupLog.Error(err, "unable to create webhook", "webhook", "Space")
-		os.Exit(1)
-	}
-	if err = (&cfv1alpha1.ClusterSpace{}).SetupWebhookWithManager(mgr); err != nil {
-		setupLog.Error(err, "unable to create webhook", "webhook", "ClusterSpace")
-		os.Exit(1)
-	}
-	if err = (&cfv1alpha1.ServiceInstance{}).SetupWebhookWithManager(mgr); err != nil {
-		setupLog.Error(err, "unable to create webhook", "webhook", "ServiceInstance")
-		os.Exit(1)
-	}
-	if err = (&cfv1alpha1.ServiceBinding{}).SetupWebhookWithManager(mgr); err != nil {
-		setupLog.Error(err, "unable to create webhook", "webhook", "ServiceBinding")
-		os.Exit(1)
+	if enableWebhooks {
+		if err = (&cfv1alpha1.Space{}).SetupWebhookWithManager(mgr); err != nil {
+			setupLog.Error(err, "unable to create webhook", "webhook", "Space")
+			os.Exit(1)
+		}
+		if err = (&cfv1alpha1.ClusterSpace{}).SetupWebhookWithManager(mgr); err != nil {
+			setupLog.Error(err, "unable to create webhook", "webhook", "ClusterSpace")
+			os.Exit(1)
+		}
+		if err = (&cfv1alpha1.ServiceInstance{}).SetupWebhookWithManager(mgr); err != nil {
+			setupLog.Error(err, "unable to create webhook", "webhook", "ServiceInstance")
+			os.Exit(1)
+		}
+		if err = (&cfv1alpha1.ServiceBinding{}).SetupWebhookWithManager(mgr); err != nil {
+			setupLog.Error(err, "unable to create webhook", "webhook", "ServiceBinding")
+			os.Exit(1)
+		}
 	}
 	// +kubebuilder:scaffold:builder
 

--- a/main.go
+++ b/main.go
@@ -59,8 +59,7 @@ func main() {
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
 	flag.StringVar(&webhookAddr, "webhook-bind-address", ":9443", "The address the webhook endpoint binds to.")
-	// TODO: where is webhookCertDir used?
-	flag.StringVar(&webhookCertDir, "webhook-tls-directory", "", "The directory containing tls server key and certificate, as tls.key and tls.crt; defaults to $TMPDIR/k8s-webhook-server/serving-certs.")
+	flag.StringVar(&webhookCertDir, "webhook-tls-directory", "", "The directory containing TLS server key and certificate, as tls.key and tls.crt; defaults to $TMPDIR/k8s-webhook-server/serving-certs.")
 	flag.BoolVar(&enableWebhooks, "enableWebhooks", true, "Enable webhooks in controller. May be disabled for local development.")
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false, "Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager.")
 	flag.StringVar(&clusterResourceNamespace, "cluster-resource-namespace", "", "The namespace for secrets in which cluster-scoped resources are found.")
@@ -123,8 +122,9 @@ func main() {
 	}
 	if enableWebhooks {
 		options.WebhookServer = webhook.NewServer(webhook.Options{
-			Host: webhookHost,
-			Port: webhookPort,
+			Host:    webhookHost,
+			Port:    webhookPort,
+			CertDir: webhookCertDir,
 		})
 	}
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), options)

--- a/pkg/metrics/transport.go
+++ b/pkg/metrics/transport.go
@@ -1,3 +1,8 @@
+/*
+SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and cf-service-operator contributors
+SPDX-License-Identifier: Apache-2.0
+*/
+
 package metrics
 
 import (

--- a/pkg/metrics/transport.go
+++ b/pkg/metrics/transport.go
@@ -1,0 +1,125 @@
+package metrics
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+)
+
+// IndependentExecutionGeneral executes several operation indepent of each other and only propagates the error value
+func IndependentExecutionGeneral(fns ...func() error) error {
+	var combinedError error
+	for _, f := range fns {
+		err := f()
+		if err != nil {
+			if combinedError == nil {
+				combinedError = err
+			} else {
+				// TODO improve error wrapping
+				// nolint:errorlint // we will improve the error wrapping in the future
+				combinedError = fmt.Errorf("%s; %s", combinedError.Error(), err.Error())
+			}
+		}
+	}
+
+	return combinedError
+}
+
+// AddMetricsToTransport injects the prometheus metrics to the http transport
+func AddMetricsToTransport(transport http.RoundTripper, registry prometheus.Registerer, target string, host string) (http.RoundTripper, error) {
+	if transport == nil {
+		transport = http.DefaultTransport
+	}
+	constLabels := prometheus.Labels{
+		"target": target,
+		"host":   host,
+	}
+
+	namespace := ""
+	subsystem := "http_client"
+	inFlightGauge := prometheus.NewGauge(prometheus.GaugeOpts{
+		Name:        "requests_in_flight",
+		Subsystem:   subsystem,
+		Namespace:   namespace,
+		Help:        "The number in-flight requests for corresponding http client",
+		ConstLabels: constLabels,
+	})
+
+	counter := prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name:        "requests_total",
+			Subsystem:   subsystem,
+			Namespace:   namespace,
+			Help:        "The number of http requests from corresponding http client",
+			ConstLabels: constLabels,
+		},
+		[]string{"code", "method"},
+	)
+
+	histVec := prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:        "request_duration_seconds",
+			Subsystem:   subsystem,
+			Namespace:   namespace,
+			Help:        "A histogram of request latencies.",
+			Buckets:     prometheus.DefBuckets,
+			ConstLabels: constLabels,
+		},
+		[]string{},
+	)
+
+	// we register the created components or replace then with the already registered ones
+	err := IndependentExecutionGeneral(
+		func() error {
+			err := registry.Register(inFlightGauge)
+			if err == nil {
+				return nil
+			}
+			var e prometheus.AlreadyRegisteredError
+			if errors.As(err, &e) {
+				if collector, ok := e.ExistingCollector.(prometheus.Gauge); ok {
+					inFlightGauge = collector
+					return nil
+				}
+			}
+			return err
+		},
+		func() error {
+			err := registry.Register(counter)
+			if err == nil {
+				return nil
+			}
+			var e prometheus.AlreadyRegisteredError
+			if errors.As(err, &e) {
+				if collector, ok := e.ExistingCollector.(*prometheus.CounterVec); ok {
+					counter = collector
+					return nil
+				}
+			}
+			return err
+		},
+		func() error {
+			err := registry.Register(histVec)
+			if err == nil {
+				return nil
+			}
+			var e prometheus.AlreadyRegisteredError
+			if errors.As(err, &e) {
+				if collector, ok := e.ExistingCollector.(*prometheus.HistogramVec); ok {
+					histVec = collector
+					return nil
+				}
+			}
+			return err
+		},
+	)
+
+	transport = promhttp.InstrumentRoundTripperInFlight(inFlightGauge, transport)
+	transport = promhttp.InstrumentRoundTripperCounter(counter, transport)
+	transport = promhttp.InstrumentRoundTripperDuration(histVec, transport)
+
+	return transport, err
+}


### PR DESCRIPTION
For analyzing issues like exceeding the rate limit on Cloud Foundry, this pull-requests adds some metrics for the HTTP transport layer of the CF clients used by this operator.

The added metrics are:
- `http_client_request_duration_seconds` (histogram)
- `http_client_requests_in_flight` (gauge)
- `http_client_requests_total` (counter)

The new functionality is accompanied by new tests in `client_test.go`.

To ease local testing, it is now possible to enable/disable the webhooks. The default is still enabled.

An example output for the metrics endpoint looks like this:

~~~
# HELP http_client_request_duration_seconds A histogram of HTTP request latencies.
# TYPE http_client_request_duration_seconds histogram
http_client_request_duration_seconds_bucket{host="http://127.0.0.1:45307",target="cf-api",le="0.005"} 1
http_client_request_duration_seconds_bucket{host="http://127.0.0.1:45307",target="cf-api",le="0.01"} 1
http_client_request_duration_seconds_bucket{host="http://127.0.0.1:45307",target="cf-api",le="0.025"} 1
http_client_request_duration_seconds_bucket{host="http://127.0.0.1:45307",target="cf-api",le="0.05"} 1
http_client_request_duration_seconds_bucket{host="http://127.0.0.1:45307",target="cf-api",le="0.1"} 1
http_client_request_duration_seconds_bucket{host="http://127.0.0.1:45307",target="cf-api",le="0.25"} 1
http_client_request_duration_seconds_bucket{host="http://127.0.0.1:45307",target="cf-api",le="0.5"} 1
http_client_request_duration_seconds_bucket{host="http://127.0.0.1:45307",target="cf-api",le="1"} 1
http_client_request_duration_seconds_bucket{host="http://127.0.0.1:45307",target="cf-api",le="2.5"} 1
http_client_request_duration_seconds_bucket{host="http://127.0.0.1:45307",target="cf-api",le="5"} 1
http_client_request_duration_seconds_bucket{host="http://127.0.0.1:45307",target="cf-api",le="10"} 1
http_client_request_duration_seconds_bucket{host="http://127.0.0.1:45307",target="cf-api",le="+Inf"} 1
http_client_request_duration_seconds_sum{host="http://127.0.0.1:45307",target="cf-api"} 0.00026072
http_client_request_duration_seconds_count{host="http://127.0.0.1:45307",target="cf-api"} 1
# HELP http_client_requests_in_flight The number in-flight requests for corresponding HTTP client
# TYPE http_client_requests_in_flight gauge
http_client_requests_in_flight{host="http://127.0.0.1:45307",target="cf-api"} 0
# HELP http_client_requests_total The number of HTTP requests from corresponding HTTP client
# TYPE http_client_requests_total counter
http_client_requests_total{code="200",host="http://127.0.0.1:45307",method="get",target="cf-api"} 1
~~~