### PR TITLE
fix client caching

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -19,18 +19,28 @@
             ]
         },
         {
-          "name": "Run integration test",
-          "type": "go",
-          "request": "launch",
-          "mode": "test",
-          "program": "${workspaceFolder}/internal/controllers",
-          "console": "internalConsole",
-          "env": {
-            "KUBEBUILDER_ASSETS": "${workspaceFolder}/bin/k8s/current",
-            "TEST_TIMEOUT": "1200",
-          },
-          "args": [],
-          "showLog": true
+            "name": "Run client test",
+            "type": "go",
+            "request": "launch",
+            "mode": "test",
+            "program": "${workspaceFolder}/internal/cf",
+            "console": "internalConsole",
+            "args": [],
+            "showLog": true
+        },
+        {
+            "name": "Run integration test",
+            "type": "go",
+            "request": "launch",
+            "mode": "test",
+            "program": "${workspaceFolder}/internal/controllers",
+            "console": "internalConsole",
+            "env": {
+              "KUBEBUILDER_ASSETS": "${workspaceFolder}/bin/k8s/current",
+              "TEST_TIMEOUT": "1200",
+            },
+            "args": [],
+            "showLog": true
         },
     ]
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,9 +20,11 @@ COPY crds/ crds/
 COPY Makefile Makefile
 
 # Run tests and build
-RUN make envtest \
- && CGO_ENABLED=0 KUBEBUILDER_ASSETS="/workspace/bin/k8s/current" go test ./... \
- && CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager main.go
+#RUN make envtest \
+# && CGO_ENABLED=0 KUBEBUILDER_ASSETS="/workspace/bin/k8s/current" go test ./... \
+# && CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager main.go
+
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,8 +21,8 @@ COPY Makefile Makefile
 
 # Run tests and build
 RUN make envtest \
-  && CGO_ENABLED=0 KUBEBUILDER_ASSETS="/workspace/bin/k8s/current" go test ./... \
-  && CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager main.go
+ && CGO_ENABLED=0 KUBEBUILDER_ASSETS="/workspace/bin/k8s/current" go test ./... \
+ && CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,11 +20,9 @@ COPY crds/ crds/
 COPY Makefile Makefile
 
 # Run tests and build
-#RUN make envtest \
-# && CGO_ENABLED=0 KUBEBUILDER_ASSETS="/workspace/bin/k8s/current" go test ./... \
-# && CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager main.go
-
-RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager main.go
+RUN make envtest \
+  && CGO_ENABLED=0 KUBEBUILDER_ASSETS="/workspace/bin/k8s/current" go test ./... \
+  && CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/internal/cf/client_test.go
+++ b/internal/cf/client_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 	"time"
 
-	cfclient "github.com/cloudfoundry-community/go-cfclient/v3/client"
 	cfResource "github.com/cloudfoundry-community/go-cfclient/v3/resource"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -92,7 +91,7 @@ var _ = Describe("CF Client tests", Ordered, func() {
 	Describe("NewOrganizationClient", func() {
 		BeforeEach(func() {
 			// Reset the cache so tests can be run independently
-			clientCache = make(map[clientIdentifier]*cfclient.Client)
+			clientCache = make(map[clientIdentifier]*clientCacheEntry)
 			// Reset server call counts
 			server.Reset()
 			// Register handlers
@@ -192,7 +191,7 @@ var _ = Describe("CF Client tests", Ordered, func() {
 	Describe("NewSpaceClient", func() {
 		BeforeEach(func() {
 			// Reset the cache so tests can be run independently
-			clientCache = make(map[clientIdentifier]*cfclient.Client)
+			clientCache = make(map[clientIdentifier]*clientCacheEntry)
 			// Reset server call counts
 			server.Reset()
 			// Register handlers

--- a/internal/cf/client_test.go
+++ b/internal/cf/client_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	cfclient "github.com/cloudfoundry-community/go-cfclient/v3/client"
 	cfResource "github.com/cloudfoundry-community/go-cfclient/v3/resource"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -21,10 +22,14 @@ import (
 // - use separate resource names to prevent collisions between tests
 
 const (
-	OrgName  = "test-org"
-	Username = "testUser"
-	Password = "testPass"
-	Owner    = "testOwner"
+	OrgName    = "test-org"
+	OrgName2   = "test-org-2"
+	SpaceName  = "test-space"
+	SpaceName2 = "test-space-2"
+	Username   = "testUser"
+	Password   = "testPass"
+	Owner      = "testOwner"
+	Owner2     = "testOwner2"
 
 	spacesURI           = "/v3/spaces"
 	serviceInstancesURI = "/v3/service_instances"
@@ -87,7 +92,7 @@ var _ = Describe("CF Client tests", Ordered, func() {
 	Describe("NewOrganizationClient", func() {
 		BeforeEach(func() {
 			// Reset the cache so tests can be run independently
-			orgClientCache = make(map[clientIdentifier]*organizationClient)
+			clientCache = make(map[clientIdentifier]*cfclient.Client)
 			// Reset server call counts
 			server.Reset()
 			// Register handlers
@@ -156,12 +161,38 @@ var _ = Describe("CF Client tests", Ordered, func() {
 
 			Expect(server.ReceivedRequests()).To(HaveLen(4))
 		})
+
+		It("should be able to query two different orgs", func() {
+			// test org 1
+			orgClient1, err1 := NewOrganizationClient(OrgName, url, Username, Password)
+			Expect(err1).To(BeNil())
+			orgClient1.GetSpace(ctx, Owner)
+			// Discover UAA endpoint
+			Expect(server.ReceivedRequests()[0].Method).To(Equal("GET"))
+			Expect(server.ReceivedRequests()[0].URL.Path).To(Equal("/"))
+			// Get new oAuth token
+			Expect(server.ReceivedRequests()[1].Method).To(Equal("POST"))
+			Expect(server.ReceivedRequests()[1].URL.Path).To(Equal(uaaURI))
+			// Get instance
+			Expect(server.ReceivedRequests()[2].Method).To(Equal("GET"))
+			Expect(server.ReceivedRequests()[2].RequestURI).To(ContainSubstring(Owner))
+
+			// test org 2
+			orgClient2, err2 := NewOrganizationClient(OrgName2, url, Username, Password)
+			Expect(err2).To(BeNil())
+			orgClient2.GetSpace(ctx, Owner2)
+			// no discovery of UAA endpoint or oAuth token here due to caching
+			// Get instance
+			Expect(server.ReceivedRequests()[3].Method).To(Equal("GET"))
+			Expect(server.ReceivedRequests()[3].RequestURI).To(ContainSubstring(Owner2))
+		})
+
 	})
 
 	Describe("NewSpaceClient", func() {
 		BeforeEach(func() {
 			// Reset the cache so tests can be run independently
-			spaceClientCache = make(map[clientIdentifier]*spaceClient)
+			clientCache = make(map[clientIdentifier]*cfclient.Client)
 			// Reset server call counts
 			server.Reset()
 			// Register handlers
@@ -230,5 +261,31 @@ var _ = Describe("CF Client tests", Ordered, func() {
 
 			Expect(server.ReceivedRequests()).To(HaveLen(4))
 		})
+
+		It("should be able to query two different spaces", func() {
+			// test space 1
+			spaceClient1, err1 := NewSpaceClient(SpaceName, url, Username, Password)
+			Expect(err1).To(BeNil())
+			spaceClient1.GetInstance(ctx, Owner)
+			// Discover UAA endpoint
+			Expect(server.ReceivedRequests()[0].Method).To(Equal("GET"))
+			Expect(server.ReceivedRequests()[0].URL.Path).To(Equal("/"))
+			// Get new oAuth token
+			Expect(server.ReceivedRequests()[1].Method).To(Equal("POST"))
+			Expect(server.ReceivedRequests()[1].URL.Path).To(Equal(uaaURI))
+			// Get instance
+			Expect(server.ReceivedRequests()[2].Method).To(Equal("GET"))
+			Expect(server.ReceivedRequests()[2].RequestURI).To(ContainSubstring(Owner))
+
+			// test space 2
+			spaceClient2, err2 := NewSpaceClient(SpaceName2, url, Username, Password)
+			Expect(err2).To(BeNil())
+			spaceClient2.GetInstance(ctx, Owner2)
+			// no discovery of UAA endpoint or oAuth token here due to caching
+			// Get instance
+			Expect(server.ReceivedRequests()[3].Method).To(Equal("GET"))
+			Expect(server.ReceivedRequests()[3].RequestURI).To(ContainSubstring(Owner2))
+		})
+
 	})
 })


### PR DESCRIPTION
Client caches were based on organizationClient and spaceClient structures that also contain values like organizationName and spaceGuid. However, this was not reflected in the key for the caching.
This causes re-use of clients that do not interact with the desired organization or space.

This PR will just cache the actual CF client and some metadata like url, username and password.
However, the structures organizationClient and spaceClient will always be created with updated values for organizationName resp spaceGuid.

Two tests are added as well to test two different organizations and two different spaces.