### PR TITLE
Pin envtest version to fix pipeline

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,9 @@
 # Image URL to use all building/pushing image targets
 IMG ?= controller:latest
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
-ENVTEST_K8S_VERSION = 1.31.0
+ENVTEST_K8S_VERSION = 1.32.0
 # ENVTEST_VERSION refers to https://github.com/kubernetes-sigs/controller-runtime/tree/main/tools/setup-envtest
-ENVTEST_VERSION = release-0.19
+ENVTEST_VERSION = release-0.20
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))


### PR DESCRIPTION
Once we have upgraded to Go 1.24, then we can upgrade to envtest latest release-0.20.

See also: https://github.com/kubernetes-sigs/controller-runtime/pull/3181